### PR TITLE
Add httpx dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ CityGitAI/
 Установите зависимости и выполните:
 
 ```bash
-pip install -r app/requirements.txt
+pip install -r app/requirements.txt  # теперь список включает httpx
 pytest
 ```
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -9,3 +9,4 @@ numpy
 torch
 jinja2
 langdetect
+httpx


### PR DESCRIPTION
## Summary
- add `httpx` to requirements
- mention the new dependency in README testing instructions

## Testing
- `pip install -r app/requirements.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68616cccbc948327a10dcac881c06c16